### PR TITLE
add support for RangeAttribute on Property<int>, Property<float> serialized fields

### DIFF
--- a/Bindings/Packages/com.virtualmaker.bindings/Editor/RangeAttributeDrawer.cs
+++ b/Bindings/Packages/com.virtualmaker.bindings/Editor/RangeAttributeDrawer.cs
@@ -1,0 +1,61 @@
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace VirtualMaker.Bindings.Editor
+{
+    [CustomPropertyDrawer(typeof(RangeAttribute))]
+    public class RangeAttributeDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            if (attribute is not RangeAttribute rangeAttribute) { return; }
+            var valueProperty = property.FindPropertyRelative("_value") ?? property;
+
+            switch (valueProperty.propertyType)
+            {
+                case SerializedPropertyType.Float:
+                    EditorGUI.Slider(position, valueProperty, rangeAttribute.min, rangeAttribute.max, label);
+                    break;
+                case SerializedPropertyType.Integer:
+                    EditorGUI.IntSlider(position, valueProperty, (int)rangeAttribute.min, (int)rangeAttribute.max, label);
+                    break;
+                default:
+                    EditorGUI.LabelField(position, label.text, $"Range not supported for {valueProperty.propertyType}");
+                    break;
+            }
+        }
+
+        public override VisualElement CreatePropertyGUI(SerializedProperty property)
+        {
+            if (attribute is not RangeAttribute rangeAttribute)
+            {
+                return base.CreatePropertyGUI(property);
+            }
+
+            var valueProperty = property.FindPropertyRelative("_value") ?? property;
+
+            switch (valueProperty.propertyType)
+            {
+                case SerializedPropertyType.Float:
+                {
+                    var propertyGui = new Slider(preferredLabel, rangeAttribute.min, rangeAttribute.max);
+                    propertyGui.AddToClassList(BaseField<float>.alignedFieldUssClassName);
+                    propertyGui.bindingPath = valueProperty.propertyPath;
+                    propertyGui.showInputField = true;
+                    return propertyGui;
+                }
+                case SerializedPropertyType.Integer:
+                {
+                    var propertyGui1 = new SliderInt(preferredLabel, (int)rangeAttribute.min, (int)rangeAttribute.max);
+                    propertyGui1.AddToClassList(BaseField<int>.alignedFieldUssClassName);
+                    propertyGui1.bindingPath = valueProperty.propertyPath;
+                    propertyGui1.showInputField = true;
+                    return propertyGui1;
+                }
+                default:
+                    return new Label($"Range not supported for {valueProperty.propertyType}");
+            }
+        }
+    }
+}

--- a/Bindings/Packages/com.virtualmaker.bindings/Editor/RangeAttributeDrawer.cs.meta
+++ b/Bindings/Packages/com.virtualmaker.bindings/Editor/RangeAttributeDrawer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 62425afe5e3feda4f8e8fb1118a6c6cf


### PR DESCRIPTION
```
[SerializeField]
[Range(0f, 1f)]
private Property<float> _testFloat = new(0.5f);

[SerializeField]
[Range(0, 10)]
private Property<int> _testInt = new(5);
```

![image](https://github.com/user-attachments/assets/7eab71d0-abc5-4156-87e1-41e517452d37)
